### PR TITLE
init: Don't run update_sys_usb_config if /data isn't mounted

### DIFF
--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -919,7 +919,9 @@ void property_load_boot_defaults(bool load_debug_prop) {
     property_initialize_ro_product_props();
     property_derive_build_fingerprint();
 
-    update_sys_usb_config();
+    if (android::base::GetBoolProperty("ro.persistent_properties.ready", false)) {
+        update_sys_usb_config();
+    }
 }
 
 static int SelinuxAuditCallback(void* data, security_class_t /*cls*/, char* buf, size_t len) {


### PR DESCRIPTION
* When /data is not mounted / not yet decrypted,
  persistent property overrides are not loaded yet
  so persist.sys.usb.config value is the one from default.prop.

  This caused adb to always be disabled on boot even if
  it was enabled in development settings.

Change-Id: Ic2a51591ad6b77f3463cfa91e9d7362410a021f2